### PR TITLE
Add Dockerfile and requirements

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,11 @@
+FROM python:3-bullseye
+MAINTAINER Aleksey Lobanov 'alex_github@likemath.ru'
+RUN apt-get update -y && apt-get install -y libgraphviz-dev build-essential
+COPY . /app
+WORKDIR /app 
+RUN pip install -r requirements.txt
+
+WORKDIR /app/web
+ENV FLASK_APP=csc.py
+CMD flask run --host=0.0.0.0
+

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,3 @@
+pygraphviz-1.9
+flask-2.0.3
+networkx-2.6.3


### PR DESCRIPTION
Hello.

Industry standard for applications deployment is docker (or OCI containers).
Fixed (at least on top level) requirements also is a good practice for projects without active development.

For simple build & run you can use this:
```
docker build --tag greedy .
docker run --name greedy -p 8000:5000 --rm greedy
```

Unfortunately, I get this error in a working application.
![image](https://user-images.githubusercontent.com/3019536/155761700-b7914e60-5fa5-4969-80f4-4fdc505e454e.png)
